### PR TITLE
Remove paylod from debug logging when creating objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.1.1
+
+- Removed payload from debug logs when creating objects.
+  Affects `manangeiq.tags_create` `manangeiq.provision_request_create`.
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## v0.1.0
 
 Initial Revision

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -76,7 +76,7 @@ class BaseAction(Action):
         return obj
 
     def _create_object(self, client, collection_name, query_dict, payload):
-        self.logger.debug("creating {} '{}' .".format(collection_name, payload))
+        self.logger.debug("creating {}.".format(collection_name))
 
         # create a new object
         collection = getattr(client.collections, collection_name)

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
     - cloudforms
     - provision
     - bestfit
-version: 0.1.0
+version: 0.1.1
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION
When creating objects we were logging the payload sent to ManageIQ. This caused issues with output sizes and could potentially leak sensitive information. Removing the payload from logging fixes the problem.