### PR TITLE
bugfix/hosts-credentials-test-not-working-with-cf47

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.1.4
+
+- Fixed error with CF 4.7 in hosts.py credential_check action
+  Contributed by John Schoewe (Encore Technologies)
+
 ## v0.1.3
 
 - Added action to refresh a given or every provider.

--- a/actions/lib/hosts.py
+++ b/actions/lib/hosts.py
@@ -12,8 +12,7 @@ class Hosts(base_action.BaseAction):
 
     def _get_hosts_query(self):
         return {'expand': 'resources',
-                'attributes': self._attributes_str(['power_status',
-                                                    'authentication_status'])}
+                'attributes': self._attributes_str(['authentication_status'])}
 
     def credentials_test(self, client, kwargs_dict):
         """Tests if the stored credentials is ManageIQ are valid for all hosts (hypervisors)

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
     - cloudforms
     - provision
     - bestfit
-version: 0.1.3
+version: 0.1.4
 python_versions:
   - "2"
   - "3"

--- a/tests/test_action_hosts.py
+++ b/tests/test_action_hosts.py
@@ -19,8 +19,7 @@ class TestActionHosts(ManageIQBaseActionTestCase):
         action = self.get_action_instance({})
         result = action._get_hosts_query()
         self.assertEquals(result, {'expand': 'resources',
-                                   'attributes': ('power_status,'
-                                                  'authentication_status')})
+                                   'attributes': ('authentication_status')})
 
     @mock.patch("lib.hosts.base_action.BaseAction._get_objects")
     def test_credentials_test(self, mock__get_objects):


### PR DESCRIPTION
Removed an unused power_status attribute that was causing the following error after upgrading to cloudforms 4.7:

manageiq_client.api.APIException: Api::BadRequestError: Invalid attributes specified: power_status